### PR TITLE
Add a method that returns the reporter

### DIFF
--- a/lib/union_station_hooks_core/api.rb
+++ b/lib/union_station_hooks_core/api.rb
@@ -77,6 +77,12 @@ module UnionStationHooks
       reporter.log_gc_stats_on_request_begin
       reporter
     end
+    
+    # Returns the reporter for the current request or `nil` if it has not
+    # been initialized yet.
+    def reporter
+      Thread.current[:union_station_hooks]
+    end
 
     # @note You do not have to call this! Passenger automatically calls
     #   this for you!


### PR DESCRIPTION
This is shorter to type, removes ambiguity and the risk of exceptionless typos (i.e. env[:union_station_hook])
